### PR TITLE
Enrich `nix flake init` with parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A registry of various `flake-parts` templates
 
 > [!WARNING] 
-> This repo is experimental. Do not promulgate *yet*.
+> This repo is experimental. Do not promulgate *until* [the GA milestone](https://github.com/flake-parts/templates/milestone/1) is complete.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# templates
+# `flake-parts` templates
+
 A registry of various `flake-parts` templates
+
+> [!WARNING] 
+> This repo is experimental. Do not promulgate *yet*.
+
+## Usage
+
+To initialize a template, run:
+
+```sh
+nix flake init -t github:flake-parts/templates#NAME
+```
+
+where `NAME` is one of the template names below:
+
+- `haskell` (alias of: `haskell-flake`)

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,154 @@
 {
   "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nix-dev-home",
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1713532798,
+        "narHash": "sha256-wtBhsdMJA3Wa32Wtm1eeo84GejtI43pMrFrmwLXrsEc=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "12e914740a25ea1891ec619bb53cf5e6ca922e40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "revCount": 57,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1715865404,
+        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix-dev-home",
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1715865404,
+        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-root": {
+      "locked": {
+        "lastModified": 1713493429,
+        "narHash": "sha256-ztz8JQkI08tjKnsTpfLqzWoKFQF4JGu2LRz8bkdnYUk=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "bc748b93b86ee76e2032eecda33440ceb2532fcd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-dev-home",
+          "nixvim",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "haskell-flake": {
       "flake": false,
       "locked": {
@@ -16,8 +165,81 @@
         "type": "github"
       }
     },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-dev-home",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1716679503,
+        "narHash": "sha256-aX8AEWHLwuiYX8OCpTnHGrQeei1Gb+AGbk1hq+RIClg=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "e4611630c3cc8ed618b48d92f6291f65be9f7913",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-dev-home",
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1716457508,
+        "narHash": "sha256-ZxzffLuWRyuMrkVVq7wastNUqeO0HJL9xqfY1QsYaqo=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "850cb322046ef1a268449cf1ceda5fd24d930b05",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-dev-home",
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1716511055,
+        "narHash": "sha256-5Fe/DGgvMhPEMl9VdVxv3zvwRcwNDmW5eRJ0gk72w7U=",
+        "owner": "lnl7",
+        "repo": "nix-darwin",
+        "rev": "0bea8222f6e83247dd13b055d83e64bce02ee532",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lnl7",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
     "nix-dev-home": {
-      "flake": false,
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "home-manager": "home-manager",
+        "nix-index-database": "nix-index-database",
+        "nixos-flake": "nixos-flake",
+        "nixpkgs": "nixpkgs",
+        "nixvim": "nixvim",
+        "systems": "systems_2"
+      },
       "locked": {
         "lastModified": 1716923620,
         "narHash": "sha256-1wFoaFGJ6bWKLUAWyFGewIm/wUqCTltx+OQYGttlBLo=",
@@ -32,7 +254,71 @@
         "type": "github"
       }
     },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-dev-home",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1716170277,
+        "narHash": "sha256-fCAiox/TuzWGVaAz16PxrR4Jtf9lN5dwWL2W74DS0yI=",
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "rev": "e0638db3db43b582512a7de8c0f8363a162842b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
+    "nixos-flake": {
+      "locked": {
+        "lastModified": 1716406291,
+        "narHash": "sha256-qHjJ6alc4o3p51hrPp3JGdC5Pbz5EjF+UZq1HbK8av0=",
+        "owner": "srid",
+        "repo": "nixos-flake",
+        "rev": "aa9100167350cbdffaa272b0fd382d7c23606b86",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "nixos-flake",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1716509168,
+        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1714640452,
+        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1716358718,
         "narHash": "sha256-NQbegJb2ZZnAqp2EJhWwTf6DrZXSpA6xZCEq+RGV1r0=",
@@ -48,11 +334,121 @@
         "type": "github"
       }
     },
+    "nixvim": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts_2",
+        "flake-root": "flake-root",
+        "home-manager": "home-manager_2",
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": [
+          "nix-dev-home",
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1716673923,
+        "narHash": "sha256-2u/NXh4FBbj8myQJTd3Are+a+qvhkXeqnpT/jq6VX2s=",
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "rev": "1cc2e02fcaabd224348fa0dbfeb311063787a060",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nix-dev-home",
+          "nixvim",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nix-dev-home",
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1716213921,
+        "narHash": "sha256-xrsYFST8ij4QWaV6HEokCUNIZLjjLP1bYC60K8XiBVA=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "0e8fcc54b842ad8428c9e705cb5994eaf05c26a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "haskell-flake": "haskell-flake",
         "nix-dev-home": "nix-dev-home",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-dev-home",
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1715940852,
+        "narHash": "sha256-wJqHMg/K6X3JGAE9YLM0LsuKrKb4XiBeVaoeMNlReZg=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "2fba33a182602b9d49f0b2440513e5ee091d838b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,7 @@
 {
   "nodes": {
     "haskell-flake": {
+      "flake": false,
       "locked": {
         "lastModified": 1716088826,
         "narHash": "sha256-jLNcBHylm1J/Q1Vz7Swsao5J8lZAhQKKSUNHl+r1K7k=",

--- a/flake.lock
+++ b/flake.lock
@@ -15,9 +15,26 @@
         "type": "github"
       }
     },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716358718,
+        "narHash": "sha256-NQbegJb2ZZnAqp2EJhWwTf6DrZXSpA6xZCEq+RGV1r0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3f316d2a50699a78afe5e77ca486ad553169061e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "haskell-flake": "haskell-flake"
+        "haskell-flake": "haskell-flake",
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,22 @@
         "type": "github"
       }
     },
+    "nix-dev-home": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1716923620,
+        "narHash": "sha256-1wFoaFGJ6bWKLUAWyFGewIm/wUqCTltx+OQYGttlBLo=",
+        "owner": "juspay",
+        "repo": "nix-dev-home",
+        "rev": "5c8f1aa430824d160e6849a311d6aa9cb8fb0f66",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "nix-dev-home",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1716358718,
@@ -35,6 +51,7 @@
     "root": {
       "inputs": {
         "haskell-flake": "haskell-flake",
+        "nix-dev-home": "nix-dev-home",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "haskell-flake": {
+      "locked": {
+        "lastModified": 1716088826,
+        "narHash": "sha256-jLNcBHylm1J/Q1Vz7Swsao5J8lZAhQKKSUNHl+r1K7k=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "440b0f1d69c1b9bb1831c29b573cf3d2e50a2c9c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "haskell-flake": "haskell-flake"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,13 @@
+{
+  inputs = {
+    # Pull templates from external flake-parts modules
+    # The pull happens in CI periodically.
+    haskell-flake.url = "github:srid/haskell-flake";
+  };
+  outputs = inputs: {
+    templates = rec {
+      haskell = haskell-flake;
+      haskell-flake = inputs.haskell-flake.templates.example;
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -65,16 +65,5 @@
 
     # To make HCI not fail; remove after adding apps or checks.
     packages.x86_64-linux.hello = inputs.nixpkgs.legacyPackages.x86_64-linux.hello;
-
-    packages.aarch64-darwin.default = inputs.nixpkgs.legacyPackages.aarch64-darwin.writeShellApplication {
-      name = "default";
-      text = ''
-        set -x
-        nix flake init -t ${inputs.self}#haskell
-        echo "# cabal-package-name"
-        ${inputs.self.templates.haskell.params.cabal-package-name.patch "my-haskell-project"}
-        echo "done!"
-      '';
-    };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -15,10 +15,10 @@
         path = builtins.path { path = inputs.haskell-flake + /example; };
         params = {
           cabal-package-name.description = "Name of the Haskell package";
-          cabal-package-name.exec = val: ''
-            mv example.cabal ${val}.cabal
-            sed -i 's/example/${val}/g' ${val}.cabal 
-            sed -i 's/example/${val}/g' flake.nix
+          cabal-package-name.exec = ''
+            mv example.cabal ''${VALUE}.cabal
+            sed -i 's/example/''${VALUE}/g' ''${VALUE}.cabal 
+            sed -i 's/example/''${VALUE}/g' flake.nix
           '';
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,8 @@
     templates = rec {
       home-manager = nix-dev-home;
       nix-dev-home = inputs.nix-dev-home.templates.default // {
+        # TODO: Ideally, these params should be moved to upstream module.
+        # But do that only as the spec stabliizes.
         params = {
           username = {
             name = "Username";

--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,22 @@
       haskell-flake = {
         description = "Haskell project template, using haskell-flake";
         path = builtins.path { path = inputs.haskell-flake + /example; };
+        # Philosophy:
+        # Templates should remain compatible with `nix flake init` (ie., the 'placeholders' as is should still build)
+        # The params, then, simply replace the placeholders
         params = {
           cabal-package-name = {
+            name = "Package Name";
             help = "Name of the Haskell package";
+            # TODO: Sometimes the default is dynamically detected?
+            # eg.: $USER
             default = "my-haskell-project";
+            # TODO: Is this a security issue?
+            # Can we do away with arbitrary shell commands?
+            # Use cases:
+            # - Placeholder replacements
+            # - Uncomment? https://github.com/juspay/nix-dev-home/issues/37
+            
             exec = ''
               mv example.cabal ''${VALUE}.cabal
               sed -i 's/example/''${VALUE}/g' ''${VALUE}.cabal 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,7 @@
 {
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
     # Pull templates from external flake-parts modules
     # The pull happens in CI periodically.
     haskell-flake.url = "github:srid/haskell-flake";
@@ -9,5 +11,8 @@
       haskell = haskell-flake;
       haskell-flake = inputs.haskell-flake.templates.example;
     };
+
+    # To make HCI not fail; remove after adding apps or checks.
+    packages.x86_64-linux.hello = inputs.nixpkgs.legacyPackages.x86_64-linux.hello;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -23,11 +23,13 @@
             # TODO: Sometimes the default is dynamically detected?
             # eg.: $USER
             default = "my-haskell-project";
+            required = false;
             # TODO: Is this a security issue?
             # Can we do away with arbitrary shell commands?
             # Use cases:
             # - Placeholder replacements
             # - Uncomment? https://github.com/juspay/nix-dev-home/issues/37
+            # - *Required* params
             
             exec = ''
               mv example.cabal ''${VALUE}.cabal

--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,29 @@
       haskell-flake = {
         description = "Haskell project template, using haskell-flake";
         path = builtins.path { path = inputs.haskell-flake + /example; };
+        params = {
+          cabal-package-name.description = "Name of the Haskell package";
+          cabal-package-name.exec = val: ''
+            mv example.cabal ${val}.cabal
+            sed -i 's/example/${val}/g' ${val}.cabal 
+            sed -i 's/example/${val}/g' flake.nix
+          '';
+        };
       };
     };
 
     # To make HCI not fail; remove after adding apps or checks.
     packages.x86_64-linux.hello = inputs.nixpkgs.legacyPackages.x86_64-linux.hello;
+
+    packages.aarch64-darwin.default = inputs.nixpkgs.legacyPackages.aarch64-darwin.writeShellApplication {
+      name = "default";
+      text = ''
+        set -x
+        nix flake init -t ${inputs.self}#haskell
+        echo "# cabal-package-name"
+        ${inputs.self.templates.haskell.params.cabal-package-name.patch "my-haskell-project"}
+        echo "done!"
+      '';
+    };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -6,40 +6,59 @@
     # The pull happens in CI periodically.
     haskell-flake.url = "github:srid/haskell-flake";
     haskell-flake.flake = false;
+    nix-dev-home.url = "github:juspay/nix-dev-home";
+    nix-dev-home.flake = false;
   };
   outputs = inputs: {
     templates = rec {
+      home-manager = nix-dev-home;
+      nix-dev-home = {
+        description = "home-manager template using nixos-flake module";
+        path = builtins.path { path = inputs.nix-dev-home; };
+        params = {
+          username = {
+            name = "Username";
+            help = "Your username as shown by by $USER";
+            default = "runner";
+            required = true;
+            files = [
+              "flake.nix"
+            ];
+          };
+          full-name = {
+            name = "Full Name";
+            help = "Your full name for use in Git config";
+            default = "John Doe";
+            required = true;
+            files = [
+              "home/default.nix"
+            ];
+          };
+          email = {
+            name = "Email";
+            help = "Your email for use in Git config";
+            default = "johndoe@example.com";
+            required = true;
+            files = [
+              "home/default.nix"
+            ];
+          };
+        };
+      };
       haskell = haskell-flake;
       haskell-flake = {
         description = "Haskell project template, using haskell-flake";
         path = builtins.path { path = inputs.haskell-flake + /example; };
-        # Philosophy:
-        # Templates should remain compatible with `nix flake init` (ie., the 'placeholders' as is should still build)
-        # The params, then, simply replace the placeholders
         params = {
           cabal-package-name = {
             name = "Package Name";
             help = "Name of the Haskell package";
-            # TODO: Sometimes the default is dynamically detected?
-            # eg.: $USER
             default = "example";
             required = false;
             files = [
               "example.cabal"
               "flake.nix"
             ];
-            # TODO: Is this a security issue?
-            # Can we do away with arbitrary shell commands?
-            # Use cases:
-            # - Placeholder replacements
-            # - Uncomment? https://github.com/juspay/nix-dev-home/issues/37
-            # - *Required* params
-            
-            exec = ''
-              mv example.cabal ''${VALUE}.cabal
-              sed -i 's/example/''${VALUE}/g' ''${VALUE}.cabal 
-              sed -i 's/example/''${VALUE}/g' flake.nix
-            '';
           };
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,12 @@
             help = "Name of the Haskell package";
             # TODO: Sometimes the default is dynamically detected?
             # eg.: $USER
-            default = "my-haskell-project";
+            default = "example";
             required = false;
+            files = [
+              "example.cabal"
+              "flake.nix"
+            ];
             # TODO: Is this a security issue?
             # Can we do away with arbitrary shell commands?
             # Use cases:

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
   outputs = inputs: {
     templates = rec {
       home-manager = nix-dev-home;
-      nix-dev-home = inputs.nix-dev-home.templates.defaut // {
+      nix-dev-home = inputs.nix-dev-home.templates.default // {
         params = {
           username = {
             name = "Username";

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,6 @@
     haskell-flake.url = "github:srid/haskell-flake";
     haskell-flake.flake = false;
     nix-dev-home.url = "github:juspay/nix-dev-home";
-    nix-dev-home.flake = false;
   };
   outputs = inputs: {
     templates = rec {

--- a/flake.nix
+++ b/flake.nix
@@ -5,11 +5,15 @@
     # Pull templates from external flake-parts modules
     # The pull happens in CI periodically.
     haskell-flake.url = "github:srid/haskell-flake";
+    haskell-flake.flake = false;
   };
   outputs = inputs: {
     templates = rec {
       haskell = haskell-flake;
-      haskell-flake = inputs.haskell-flake.templates.example;
+      haskell-flake = {
+        description = "Haskell project template, using haskell-flake";
+        path = builtins.path { path = inputs.haskell-flake + /example; };
+      };
     };
 
     # To make HCI not fail; remove after adding apps or checks.

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         params = {
           cabal-package-name = {
             help = "Name of the Haskell package";
-            placeholder = "my-haskell-project";
+            default = "my-haskell-project";
             exec = ''
               mv example.cabal ''${VALUE}.cabal
               sed -i 's/example/''${VALUE}/g' ''${VALUE}.cabal 

--- a/flake.nix
+++ b/flake.nix
@@ -12,9 +12,7 @@
   outputs = inputs: {
     templates = rec {
       home-manager = nix-dev-home;
-      nix-dev-home = {
-        description = "home-manager template using nixos-flake module";
-        path = builtins.path { path = inputs.nix-dev-home; };
+      nix-dev-home = inputs.nix-dev-home.templates.defaut // {
         params = {
           username = {
             name = "Username";

--- a/flake.nix
+++ b/flake.nix
@@ -14,15 +14,20 @@
         description = "Haskell project template, using haskell-flake";
         path = builtins.path { path = inputs.haskell-flake + /example; };
         params = {
-          cabal-package-name.description = "Name of the Haskell package";
-          cabal-package-name.exec = ''
-            mv example.cabal ''${VALUE}.cabal
-            sed -i 's/example/''${VALUE}/g' ''${VALUE}.cabal 
-            sed -i 's/example/''${VALUE}/g' flake.nix
-          '';
+          cabal-package-name = {
+            help = "Name of the Haskell package";
+            placeholder = "my-haskell-project";
+            exec = ''
+              mv example.cabal ''${VALUE}.cabal
+              sed -i 's/example/''${VALUE}/g' ''${VALUE}.cabal 
+              sed -i 's/example/''${VALUE}/g' flake.nix
+            '';
+          };
         };
       };
     };
+
+    formatter.aarch64-darwin = inputs.nixpkgs.legacyPackages.aarch64-darwin.nixpkgs-fmt;
 
     # To make HCI not fail; remove after adding apps or checks.
     packages.x86_64-linux.hello = inputs.nixpkgs.legacyPackages.x86_64-linux.hello;


### PR DESCRIPTION
Enrich flake templates with a `params` attribute (eventually, these params will be upstreamed to the respective repos) that defines what to replace in the generated project directory post `nix flake init`. 

This is meant to be consumed by https://github.com/juspay/flakreate which program does the following:

- Reads a registry of flake templates (by default, this repo)
- Prompt the user to pick a template
- Run `nix flake init` on it
- Prompt the user to choose replacement values (per the `params` spec, as you can see defined in this PR)
- Do the appropriate replacements.

Here's what it looks like to initialize https://github.com/juspay/nix-dev-home whilst doing the appropriate replacements (user name, email):

https://asciinema.org/a/rCOqlKyA3Og8b5WalKV9d1k97

To try this out locally,

```
nix run github:juspay/flakreate
```