### PR TITLE
Add `tags` property to templates

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
       };
       flake = {
         # TODO: Ideally, these params should be moved to upstream module.
-        # But do that only as the spec stabliizes.
+        # But do that only as the spec stabilizes.
         templates = rec {
           nix-dev-home = inputs.nix-dev-home.templates.default // {
             tags = [ "home-manager" "juspay" "development" ];

--- a/flake.nix
+++ b/flake.nix
@@ -28,11 +28,11 @@
         };
       };
       flake = {
+        # TODO: Ideally, these params should be moved to upstream module.
+        # But do that only as the spec stabliizes.
         templates = rec {
-          home-manager = nix-dev-home;
           nix-dev-home = inputs.nix-dev-home.templates.default // {
-            # TODO: Ideally, these params should be moved to upstream module.
-            # But do that only as the spec stabliizes.
+            tags = [ "home-manager" "juspay" "development" ];
             params = [
               {
                 name = "Username";
@@ -71,10 +71,10 @@
               }
             ];
           };
-          haskell = haskell-flake;
           haskell-flake = {
             description = "Haskell project template, using haskell-flake";
             path = builtins.path { path = inputs.haskell-flake + /example; };
+            tags = [ "haskell" "haskell-flake" ];
             params = [
               {
                 name = "Package Name";
@@ -91,6 +91,7 @@
           haskell-template = {
             description = "A batteries-included Haskell project template";
             path = builtins.path { path = inputs.haskell-template; };
+            tags = [ "haskell" "haskell-flake" "relude" "just" ];
             params = [
               {
                 name = "Package Name";


### PR DESCRIPTION
In flakreate, we can then display these tags alongside template name:

<img width="478" alt="image" src="https://github.com/flake-parts/templates/assets/3998/4567572b-e749-46a2-a13b-725a370f686d">

Which the user can search alongside template name:

<img width="418" alt="image" src="https://github.com/flake-parts/templates/assets/3998/2bdf79fe-85d2-4de9-8fe6-12080d2f4655">

This allows the template to be named however the author wants whilst still allowing sensible search by the user. For eg., `nix-dev-home` will pop-up when someone searches for `home-manager`.